### PR TITLE
async-loop-until: New ns, core.async with loop-until fn.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:deps {org.clojure/tools.deps.alpha {:mvn/version "0.11.905"}
-        org.clojure/clojure {:mvn/version "1.10.3"}}
+        org.clojure/clojure {:mvn/version "1.10.3"}
+        org.clojure/core.async {:mvn/version "1.3.610"}}
 
  :paths ["src"]
 

--- a/src/clj_contrib/core/async.clj
+++ b/src/clj_contrib/core/async.clj
@@ -1,0 +1,38 @@
+(ns clj-contrib.core.async
+  (:gen-class)
+  (:require [clojure.core.async :as async]))
+
+(defn loop-until
+  "Pulls results from a `c` async channel and executes `f` function against
+   the result. Stops if the `f` function returns false/nil or the `max` is
+   exceeded.
+   - c: A core.async channel.
+   - f: Function applied to the value taken from the channel. If this function's
+        return value is falsey, the loop exits.
+   - max: The max number of loops to execute, regardless of f return value."
+  [c f max]
+  (loop [i 0]
+    (when (< i max)
+      (-> c
+          async/<!!
+          f
+          (when (recur (inc i)))))))
+
+(comment
+  ;; stops early when the :error is encountered.
+  (let [ch (async/chan)
+        stop-on-error (fn [result] (println result) (not (contains? result :error)))]
+    (async/put! ch {:success "some data"})
+    (async/put! ch {:error "bad data"})
+    (async/put! ch {:success "more data"})
+    (async/put! ch {:success "data trifecta"})
+    (loop-until ch stop-on-error 3))
+
+  ;; executes to the max of 3
+  (let [ch (async/chan)
+        stop-on-error (fn [result] (println result) (not (contains? result :error)))]
+    (async/put! ch {:success "some data"})
+    (async/put! ch {:success "more data"})
+    (async/put! ch {:success "data trifecta"})
+    (async/put! ch {:error "bad data"})
+    (loop-until ch stop-on-error 3)))


### PR DESCRIPTION
- New fn, core.async/loop-until, executes a passed in function against an async channel output until a falsey value is returned or the max is exceeded.